### PR TITLE
Workaround for broken SPKAC generated by Chrome

### DIFF
--- a/pyspkac/spkac.py
+++ b/pyspkac/spkac.py
@@ -162,7 +162,7 @@ class SPKAC (PEM_Object) :
         1
         >>> spkac.cert.check_purpose (m2.X509_PURPOSE_NS_SSL_SERVER, 0)
         1
-        >>> spkac.cert.check_purpose (m2.X509_PURPOSE_ANY, 0)   
+        >>> spkac.cert.check_purpose (m2.X509_PURPOSE_ANY, 0)
         1
         >>> spkac.cert.check_purpose (m2.X509_PURPOSE_SSL_CLIENT, 0)
         1
@@ -216,9 +216,9 @@ class SPKAC (PEM_Object) :
             raise SPKAC_Decode_Error (e)
         if rest :
             raise SPKAC_Decode_Error ("ASN.1 decode: data after SPKAC value")
-        if len (seq) != 3 or len (seq [0]) != 2 or len (seq [1]) != 2 :
+        if len (seq) != 3 or len (seq [0]) != 2 or len (seq [1]) not in (1, 2) :
             raise SPKAC_Decode_Error ("Unknown SPKAC data format")
-        if seq [1][1] :
+        if len (seq [1]) == 2 and seq [1][1] :
             raise SPKAC_Decode_Error ("Invalid Public Key Info")
         self.signed    = der_encode (seq [0])
         self.spki      = seq [0][0]


### PR DESCRIPTION
Valid SPKAC asn1parse:

```
    0:d=0  hl=4 l= 585 cons: SEQUENCE
    4:d=1  hl=4 l= 305 cons:  SEQUENCE
    8:d=2  hl=4 l= 290 cons:   SEQUENCE
   12:d=3  hl=2 l=  13 cons:    SEQUENCE
   14:d=4  hl=2 l=   9 prim:     OBJECT            :rsaEncryption
   25:d=4  hl=2 l=   0 prim:     NULL
   27:d=3  hl=4 l= 271 prim:    BIT STRING
  302:d=2  hl=2 l=   9 prim:   IA5STRING         :challenge
  313:d=1  hl=2 l=  13 cons:  SEQUENCE
  315:d=2  hl=2 l=   9 prim:   OBJECT            :md5WithRSAEncryption
  326:d=2  hl=2 l=   0 prim:   NULL
  328:d=1  hl=4 l= 257 prim:  BIT STRING
```

Offending SPKAC generated by Chrome:

```
    0:d=0  hl=4 l= 572 cons: SEQUENCE
    4:d=1  hl=4 l= 294 cons:  SEQUENCE
    8:d=2  hl=4 l= 288 cons:   SEQUENCE
   12:d=3  hl=2 l=  11 cons:    SEQUENCE
   14:d=4  hl=2 l=   9 prim:     OBJECT            :rsaEncryption
   25:d=3  hl=4 l= 271 prim:    BIT STRING
  300:d=2  hl=2 l=   0 prim:   IA5STRING         :
  302:d=1  hl=2 l=  11 cons:  SEQUENCE
  304:d=2  hl=2 l=   9 prim:   OBJECT            :md5WithRSAEncryption
  315:d=1  hl=4 l= 257 prim:  BIT STRING
```
